### PR TITLE
[ENHANCEMENT] Moved hidden file sourcing

### DIFF
--- a/zsh/.zsh_profile
+++ b/zsh/.zsh_profile
@@ -1,10 +1,2 @@
 # Add `~/bin` to the `$PATH`
 export PATH="/usr/local/bin:$PATH"
-
-# Load the shell dotfiles, and then some:
-# * ~/.path can be used to extend `$PATH`.
-# * ~/.extra can be used for other settings you don’t want to commit.
-for file in ~/.{path,extras}; do
-    [ -r "$file" ] && [ -f "$file" ] && source "$file";
-done;
-unset file;

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -34,6 +34,14 @@ source $ZSH/oh-my-zsh.sh
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8
 
+# Load the shell dotfiles, and then some:
+# * ~/.path can be used to extend `$PATH`.
+# * ~/.extra can be used for other settings you don’t want to commit.
+for file in ~/.{path,extras}; do
+    [ -r "$file" ] && [ -f "$file" ] && source "$file";
+done;
+unset file;
+
 #==============================================================================
 # ALIASES
 #==============================================================================
@@ -64,4 +72,3 @@ export NVM_DIR="$HOME/.nvm"
 # JAVA
 #==============================================================================
 eval "$(jenv init -)"
-


### PR DESCRIPTION
When the init for hidden files was in the zsh_profile they would not be
available in new terminal tabs - which means the user has to restart the
terminal each time - very annoying.

This change will make it so the dev does not have to source the profile
all the time.